### PR TITLE
sof-cht-bsw-rt5672: initial import

### DIFF
--- a/ucm/sof-cht-bsw-rt5672/HiFi.conf
+++ b/ucm/sof-cht-bsw-rt5672/HiFi.conf
@@ -1,0 +1,25 @@
+# Adapted from cht-bsw-rt5672
+
+SectionVerb {
+	EnableSequence [
+		cdev "hw:sofchtbswrt5672"
+		<codecs/rt5672/EnableSeq.conf>
+	]
+
+	DisableSequence [
+		cdev "hw:sofchtbswrt5672"
+	]
+
+	Value {
+		PlaybackPCM "hw:sofchtbswrt5672"
+		CapturePCM "hw:sofchtbswrt5672"
+	}
+}
+
+<codecs/rt5672/Speaker.conf>
+<codecs/rt5672/MonoSpeaker.conf>
+<codecs/rt5672/HeadPhones.conf>
+
+<codecs/rt5672/DMIC1.conf>
+<codecs/rt5672/DMIC2.conf>
+<codecs/rt5672/HeadsetMic.conf>

--- a/ucm/sof-cht-bsw-rt5672/sof-cht-bsw-rt5672.conf
+++ b/ucm/sof-cht-bsw-rt5672/sof-cht-bsw-rt5672.conf
@@ -1,0 +1,6 @@
+# Adapted from cht-bsw-rt5672
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play HiFi quality Music"
+}


### PR DESCRIPTION
based on cht-bsw-rt5672, with the SST stuff removed

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>