### PR TITLE
sof-chtrt5645: initial import

### DIFF
--- a/ucm/sof-chtrt5645/HiFi.conf
+++ b/ucm/sof-chtrt5645/HiFi.conf
@@ -1,0 +1,116 @@
+SectionVerb {
+	# ALSA PCM
+	Value {
+		TQ "HiFi"
+
+		# ALSA PCM device for HiFi
+		PlaybackPCM "hw:sofchtrt5645"
+		CapturePCM "hw:sofchtrt5645"
+	}
+
+	EnableSequence [
+		cdev "hw:sofchtrt5645"
+
+		<codecs/rt5645/EnableSeq.conf>
+
+		cset "name='Stereo1 ADC1 Mux' 1"
+		cset "name='I2S2 Func Switch' on"
+		# 3/12 the headphone mic tends to be quite loud
+		cset "name='IN1 Boost' 3"
+		# 8/8 the internal analog mic tends to be quite soft
+		cset "name='IN2 Boost' 8"
+	]
+
+	DisableSequence [
+		cdev "hw:sofchtrt5645"
+
+		<codecs/rt5645/DisableSeq.conf>
+	]
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	Value {
+		PlaybackChannels "2"
+	}
+
+	ConflictingDevice [
+		"Headphones"
+	]
+
+	EnableSequence [
+		cdev "hw:sofchtrt5645"
+
+		<codecs/rt5645/SpeakerEnableSeq.conf>
+	]
+
+	DisableSequence [
+		cdev "hw:sofchtrt5645"
+
+		cset "name='Ext Spk Switch' off"
+		cset "name='Speaker Channel Switch' off"
+	]
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones"
+
+	Value {
+		PlaybackChannels "2"
+		JackControl "Headphone Jack"
+		JackHWMute "Speaker"
+	}
+
+	ConflictingDevice [
+		"Speaker"
+	]
+
+	EnableSequence [
+		cdev "hw:sofchtrt5645"
+
+		<codecs/rt5645/HeadphonesEnableSeq.conf>
+	]
+
+	DisableSequence [
+		cdev "hw:sofchtrt5645"
+
+		cset "name='Headphone Switch' off"
+		cset "name='Headphone Channel Switch' off"
+	]
+}
+
+<codecs/rt5645/AnalogMic.conf>
+
+SectionDevice."HSMic".0 {
+	Comment "Headset Microphone"
+
+	Value {
+		CaptureChannels "2"
+		JackControl "Headset Mic Jack"
+		JackHWMute "Mic"
+	}
+
+	EnableSequence [
+		cdev "hw:sofchtrt5645"
+
+		<codecs/rt5645/HSMicEnableSeq.conf>
+
+		cset "name='Sto1 ADC MIXL ADC2 Switch' off"
+		cset "name='Sto1 ADC MIXR ADC2 Switch' off"
+
+		cset "name='Mono ADC MIXL ADC1 Switch' on"
+		cset "name='Mono ADC MIXR ADC1 Switch' on"
+		cset "name='Mono ADC MIXL ADC2 Switch' off"
+		cset "name='Mono ADC MIXR ADC2 Switch' off"
+	]
+
+	DisableSequence [
+		cdev "hw:sofchtrt5645"
+
+		<codecs/rt5645/HSMicDisableSeq.conf>
+
+		cset "name='Mono ADC MIXL ADC1 Switch' on"
+		cset "name='Mono ADC MIXR ADC1 Switch' on"
+	]
+}

--- a/ucm/sof-chtrt5645/sof-chtrt5645.conf
+++ b/ucm/sof-chtrt5645/sof-chtrt5645.conf
@@ -1,0 +1,5 @@
+Comment "Intel SoC Audio Device"
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Default"
+}


### PR DESCRIPTION
based on chtrt5645, with device names changed and SST stuff removed

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>