### PR TITLE
sof-sdw-rt711-1308-715: move to common HDMI codec driver

### DIFF
--- a/ucm/sof-sdw-rt711-1308-715/HiFi
+++ b/ucm/sof-sdw-rt711-1308-715/HiFi
@@ -80,20 +80,18 @@ SectionDevice."HDMI1" {
 
 	EnableSequence [
 		cdev "hw:sofsdwrt7111308"
-		cset "name='hif5-0 Jack Switch' on"
-		cset "name='Pin5-Port0 Mux' 1"
+		cset "name='IEC958 Playback Switch' on"
 	]
 
 	DisableSequence [
 		cdev "hw:sofsdwrt7111308"
-		cset "name='Pin5-Port0 Mux' 0"
-		cset "name='hif5-0 Jack Switch' off"
+		cset "name='IEC958 Playback Switch' off"
 	]
 
 	Value {
 		PlaybackPCM "hw:sofsdwrt7111308,5"
 		PlaybackChannels "2"
-		JackControl "HDMI/DP, pcm=5 Jack"
+		JackControl "HDMI/DP,pcm=5 Jack"
 	}
 }
 
@@ -102,20 +100,18 @@ SectionDevice."HDMI2" {
 
 	EnableSequence [
 		cdev "hw:sofsdwrt7111308"
-		cset "name='hif6-0 Jack Switch' on"
-		cset "name='Pin6-Port0 Mux' 2"
+		cset "name='IEC958 Playback Switch',index=1 on"
 	]
 
 	DisableSequence [
 		cdev "hw:sofsdwrt7111308"
-		cset "name='Pin6-Port0 Mux' 0"
-		cset "name='hif6-0 Jack Switch' off"
+		cset "name='IEC958 Playback Switch',index=1 off"
 	]
 
 	Value {
 		PlaybackPCM "hw:sofsdwrt7111308,6"
 		PlaybackChannels "2"
-		JackControl "HDMI/DP, pcm=6 Jack"
+		JackControl "HDMI/DP,pcm=6 Jack"
 	}
 }
 
@@ -124,19 +120,17 @@ SectionDevice."HDMI3" {
 
 	EnableSequence [
 		cdev "hw:sofsdwrt7111308"
-		cset "name='hif7-0 Jack Switch' on"
-		cset "name='Pin7-Port0 Mux' 3"
+		cset "name='IEC958 Playback Switch',index=2 on"
 	]
 
 	DisableSequence [
 		cdev "hw:sofsdwrt7111308"
-		cset "name='Pin7-Port0 Mux' 0"
-		cset "name='hif7-0 Jack Switch' off"
+		cset "name='IEC958 Playback Switch',index=2 off"
 	]
 
 	Value {
 		PlaybackPCM "hw:sofsdwrt7111308,7"
 		PlaybackChannels "2"
-		JackControl "HDMI/DP, pcm=7 Jack"
+		JackControl "HDMI/DP,pcm=7 Jack"
 	}
 }


### PR DESCRIPTION
Modify UCM rules to configure HDMI using common HDMI codec
driver controls.

After this change, the UCM is no longer compatile with
hdac-hdmi codec driver.

Fixes: https://github.com/thesofproject/linux/issues/1438