### PR TITLE
sof-skl_hda_card: DMIC use sofsklhdacard for card number

### DIFF
--- a/ucm/LENOVO-20QE000VMC-ThinkPadX1Carbon7th-20QE000VMC/Mics.conf
+++ b/ucm/LENOVO-20QE000VMC-ThinkPadX1Carbon7th-20QE000VMC/Mics.conf
@@ -14,7 +14,7 @@ SectionDevice."Headset Microphone" {
 	]
 
 	Value {
-		CapturePCM "hw:0,0"
+		CapturePCM "hw:sofsklhdacard,0"
 		CaptureVolume "Capture"
 		CaptureSwitch "Capture Switch"
 		CaptureChannels "2"
@@ -41,7 +41,7 @@ SectionDevice."Dmic" {
 	]
 
 	Value {
-		CapturePCM "hw:0,6"
+		CapturePCM "hw:sofsklhdacard,6"
 		CaptureVolume "Dmic0 Capture Volume"
 		CaptureSwitch "Dmic0 Capture Switch"
 		CaptureChannels "2"

--- a/ucm/sof-skl_hda_card/Mics.conf
+++ b/ucm/sof-skl_hda_card/Mics.conf
@@ -16,7 +16,7 @@ SectionDevice."Headset Microphone" {
 	]
 
 	Value {
-		CapturePCM "hw:0,0"
+		CapturePCM "hw:sofsklhdacard,0"
 		CaptureVolume "Capture"
 		CaptureSwitch "Capture Switch"
 		CaptureChannels "2"
@@ -45,7 +45,7 @@ SectionDevice."Headphone Microphone" {
         ]
 
         Value {
-		CapturePCM "hw:0,0"
+		CapturePCM "hw:sofsklhdacard,0"
 		CaptureVolume "Capture"
 		CaptureSwitch "Capture Switch"
 		CaptureChannels "2"
@@ -73,7 +73,7 @@ SectionDevice."Dmic" {
 	]
 
 	Value {
-		CapturePCM "hw:0,6"
+		CapturePCM "hw:sofsklhdacard,6"
 		CaptureVolume "Dmic0 Capture Volume"
 		CaptureSwitch "Dmic0 Capture Switch"
 		CaptureChannels "2"


### PR DESCRIPTION
As Mengdong required, I submitted the patch again, which is from the patchset  https://github.com/thesofproject/alsa-ucm-conf/pull/13

The card number can be changed. Change "hw:0" to "hw:sofsklhdacard"

Signed-off-by: Libin Yang <libin.yang@linux.intel.com>