### PR TITLE
sof-skl_hda_card: set capture default volume

### DIFF
--- a/ucm/sof-skl_hda_card/sof-skl_hda_card.conf
+++ b/ucm/sof-skl_hda_card/sof-skl_hda_card.conf
@@ -26,4 +26,9 @@ SectionDefaults [
 	cset "name='Headphone Playback Volume' 80"
 	cset "name='Speaker Playback Volume' 80"
 	cset "name='Auto-Mute Mode' off"
+	cset "name='Capture Volume' 50"
+	cset "name='Headset Mic Boost Volume' 1"
+	cset "name='PGA2.0 2 Master Capture Volume' 60"
+	cset "name='PGA10.0 10 Master Capture Volume' 75"
+	cset "name='PGA11.0 11 Master Capture Volume' 75"
 ]


### PR DESCRIPTION
Set the capture default volume to avoid the initial volume is
too slow or too loud.

Signed-off-by: Libin Yang <libin.yang@linux.intel.com>