### PR TITLE
ucm2: add sof-rt5682

### DIFF
--- a/ucm2/sof-rt5682/HiFi.conf
+++ b/ucm2/sof-rt5682/HiFi.conf
@@ -1,0 +1,49 @@
+# Use case Configuration for sof-hda-dsp
+
+SectionVerb {
+}
+
+SectionDevice."Headphone1" {
+	Comment "Low latency playback"
+
+	ConflictingDevice [
+		"MediaPlayback"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackVolume "PGA1.0 1 PCM 0 Playback Volume"
+		PlaybackSwitch "Headphone Jack Switch"
+		PlaybackChannels "2"
+	}
+}
+
+SectionDevice."MediaPlayback" {
+	Comment "Media Playback"
+
+	ConflictingDevice [
+		"Headphone1"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackVolume "PGA3.0 3 PCM 1 Playback Volume"
+		PlaybackSwitch "Headphone Jack Switch"
+		PlaybackChannels "2"
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Low Latency Stereo Microphone"
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},0"
+		CaptureVolume "STO1 ADC Capture Volume"
+		CaptureSwitch "Headset Mic Switch"
+		CaptureChannels "2"
+	}
+}
+

--- a/ucm2/sof-rt5682/sof-rt5682.conf
+++ b/ucm2/sof-rt5682/sof-rt5682.conf
@@ -1,0 +1,34 @@
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play HiFi quality Music"
+}
+
+SectionDefaults [
+	# playback
+	cset "name='Headphone Jack Switch' on"
+	cset "name='DAC1 Playback Volume' 70"
+	cset "name='DAC L1 Source' 'DAC1'"
+	cset "name='DAC R1 Source' 'DAC1'"
+	cset "name='DAC1 MIXL DAC1 Switch' on"
+	cset "name='DAC1 MIXL Stereo ADC Switch' off"
+	cset "name='DAC1 MIXR DAC1 Switch' on"
+	cset "name='DAC1 MIXR Stereo ADC Switch' off"
+	cset "name='HPOL Playback Switch' on"
+	cset "name='HPOR Playback Switch' on"
+	cset "name='PGA1.0 1 PCM 0 Playback Volume' 28"
+	cset "name='PGA1.1 1 Master Playback Volume' 28"
+	cset "name='PGA3.0 3 PCM 1 Playback Volume' 28"
+
+	# capture
+	cset "name='CBJ Boost Volume' 2"
+	cset "name='Headset Mic Switch' on"
+	cset "name='RECMIX1L CBJ Switch' on"
+	cset "name='STO1 ADC Boost Gain Volume' 1"
+	cset "name='Stereo1 ADC L Mux' 'ADC1 L'"
+	cset "name='Stereo1 ADC MIXL ADC1 Switch' on"
+	cset "name='PGA2.0 2 PCM 0 Capture Volume' 35"
+	cset "name='STO1 ADC Capture Volume' 35"
+	cset "name='STO1 ADC Boost Gain Volume' 1"
+]


### PR DESCRIPTION
sof-rt5682 ucm2 conf is for the platform byt rt5682 platforms.

Signed-off-by: Libin Yang <libin.yang@linux.intel.com>