### PR TITLE
ucm2: add apl-pcm512x support

### DIFF
--- a/ucm2/sof-bxt-pcm512x/Hdmi.conf
+++ b/ucm2/sof-bxt-pcm512x/Hdmi.conf
@@ -1,0 +1,64 @@
+# Use case Configuration for sof-hda-dsp
+
+SectionDevice."HDMI1" {
+	Comment "HDMI1/DP1 Output"
+
+	EnableSequence [
+		cset "name='IEC958 Playback Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='IEC958 Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPriority 500
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackVolume "PGA2.0 2 Master Playback Volume"
+		PlaybackSwitch "IEC958 Playback Switch"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=1 Jack"
+	}
+}
+
+SectionDevice."HDMI2" {
+	Comment "HDMI2/DP2 Output"
+
+	EnableSequence [
+		cset "name='IEC958 Playback Switch',index=1 on"
+	]
+
+	DisableSequence [
+		cset "name='IEC958 Playback Switch',index=1 off"
+	]
+
+	Value {
+		PlaybackPriority 600
+		PlaybackPCM "hw:${CardId},2"
+		PlaybackVolume "PGA3.0 3 Master Playback Volume"
+		PlaybackSwitch "'IEC958 Playback Switch',index=1"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=2 Jack"
+	}
+}
+
+SectionDevice."HDMI3" {
+	Comment "HDMI3/DP3 Output"
+
+	EnableSequence [
+		cset "name='IEC958 Playback Switch',index=2 on"
+	]
+
+	DisableSequence [
+		cset "name='IEC958 Playback Switch',index=2 off"
+	]
+
+	Value {
+		PlaybackPriority 700
+		PlaybackPCM "hw:${CardId},3"
+		PlaybackVolume "PGA4.0 4 Master Playback Volume"
+		PlaybackSwitch "'IEC958 Playback Switch',index=2"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=3 Jack"
+	}
+}

--- a/ucm2/sof-bxt-pcm512x/HiFi.conf
+++ b/ucm2/sof-bxt-pcm512x/HiFi.conf
@@ -1,0 +1,38 @@
+# Use case Configuration for sof-hda-dsp
+
+SectionVerb {
+}
+
+SectionDevice."Headphone" {
+	Comment "Headphone"
+
+	ConflictingDevice [
+		"MediaPlayback"
+	]
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackVolume "PGA1.0 1 PCM 0 Playback Volume"
+		PlaybackSwitch "Digital Playback Switch"
+		PlaybackChannels "2"
+	}
+}
+
+SectionDevice."MediaPlayback" {
+	Comment "Media Playback"
+
+	ConflictingDevice [
+		"Headphone"
+	]
+
+	Value {
+		PlaybackPriority 100
+		PlaybackPCM "hw:${CardId},4"
+		PlaybackVolume "PGA5.0 5 PCM 4 Playback Volume"
+		PlaybackSwitch "Digital Playback Switch"
+		PlaybackChannels "2"
+	}
+}
+
+<sof-bxt-pcm512x/Hdmi.conf>

--- a/ucm2/sof-bxt-pcm512x/sof-bxt-pcm512x.conf
+++ b/ucm2/sof-bxt-pcm512x/sof-bxt-pcm512x.conf
@@ -1,0 +1,18 @@
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play HiFi quality Music"
+}
+
+SectionDefaults [
+	cset "name='Auto Mute Switch' off"
+	cset "name='Auto Mute Mono Switch' off"
+	cset "name='Digital Playback Switch' on"
+	cset "name='Digital Playback Volume' 210"
+	cset "name='PGA1.0 1 PCM 0 Playback Volume' 28"
+	cset "name='PGA1.1 1 Master Playback Volume' 28"
+	cset "name='Digital Playback Switch' on"
+	cset "name='Digital Playback Volume' 210"
+	cset "name='PGA5.0 5 PCM 4 Playback Volume' 28"
+]


### PR DESCRIPTION
This patch adds the ucm2 support for platform apl-pcm512x

Signed-off-by: Libin Yang <libin.yang@linux.intel.com>