### PR TITLE
ucm2: add sof-nocodec support

### DIFF
--- a/ucm2/sof-nocodec/HiFi.conf
+++ b/ucm2/sof-nocodec/HiFi.conf
@@ -1,0 +1,188 @@
+SectionVerb {
+	EnableSequence [
+	]
+}
+
+# for nocodec playback:
+# pipeline 1 <=> pcm 0
+# pipeline 3 <=> pcm 1
+# pipeline 5 <=> pcm 2
+# pipeline 7 <=> pcm 3
+# pipeline 9 <=> pcm 4
+# pipeline 11 <=> pcm 5
+# pipeline 13 <=> pcm 7
+SectionDevice."Headset1 Headphone" {
+	Comment "Stereo Headeset 1 Headphone"
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackVolume "PGA1.0 1 PCM 0 Playback Volume"
+		PlaybackChannels "2"
+	}
+}
+
+SectionDevice."Headset1 Headmic" {
+	Comment "Stereo Headset 1 Headmic"
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},0"
+		If.master {
+			Condition {
+				Type ControlExists
+				Control "name='PGA2.0 2 Master Capture Volume'"
+			}
+			True {
+				CaptureVolume "PGA2.0 2 Master Capture Volume"
+			}
+			False {
+				CaptureVolume "PGA2.0 2 PCM 0 Capture Volume"
+			}
+		}
+		CaptureChannels "2"
+	}
+}
+
+SectionDevice."Headset2 Headphone" {
+	Comment "Stereo Headset 2 Headphone"
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId},1"
+		If.master {
+			Condition {
+				Type ControlExists
+				Control "name='PGA3.0 3 Master Playback Volume'"
+			}
+			True {
+				PlaybackVolume "PGA3.0 3 Master Playback Volume"
+			}
+			False {
+				PlaybackVolume "PGA3.0 3 PCM 1 Playback Volume"
+			}
+		}
+		PlaybackChannels "2"
+	}
+}
+
+
+If.pipe4 {
+	Condition {
+		Type ControlExists
+		Control "name='PGA4.0 4 Master Capture Volume'"
+	}
+	True {
+		SectionDevice."Headset2 Headmic" {
+			Comment "Stereo Headset 2 Headmic"
+			Value {
+				CapturePriority 200
+				CapturePCM "hw:${CardId},1"
+				CaptureVolume "PGA4.0 4 Master Capture Volume"
+				CaptureChannels "2"
+			}
+		}
+	}
+}
+
+If.pipe7 {
+	Condition {
+		Type ControlExists
+		Control "name='PGA7.0 7 Master Playback Volume'"
+	}
+	True {
+		SectionDevice."Headset4 Headphone" {
+			Comment "Stereo Headset 4 Headphone"
+			Value {
+				PlaybackPriority 200
+				PlaybackPCM "hw:${CardId},3"
+				PlaybackVolume "PGA7.0 7 Master Playback Volume"
+				PlaybackChannels "2"
+			}
+		}
+	}
+}
+
+If.pipe8 {
+	Condition {
+		Type ControlExists
+		Control "name='PGA8.0 8 Master Capture Volume'"
+	}
+	True {
+		SectionDevice."Headset4 Headmic" {
+			Comment "Stereo Headset 4 Headmic"
+			Value {
+				CapturePriority 200
+				CapturePCM "hw:${CardId},3"
+				CaptureVolume "PGA8.0 8 Master Capture Volume"
+				CaptureChannels "2"
+			}
+		}
+	}
+}
+
+If.pipe11 {
+	Condition {
+		Type ControlExists
+		Control "name='PGA11.0 11 Master Playback Volume'"
+	}
+	True {
+		SectionDevice."Headset6 Headphone" {
+			Comment "Stereo Headset 6 Headphone"
+			Value {
+				PlaybackPriority 200
+				PlaybackPCM "hw:${CardId},5"
+				PlaybackVolume "PGA11.0 11 Master Playback Volume"
+				PlaybackChannels "2"
+			}
+		}
+	}
+}
+
+If.pipe12 {
+	Condition {
+		Type ControlExists
+		Control "name='PGA12.0 12 Master Capture Volume'"
+	}
+	True {
+		SectionDevice."Headset6 Headmic" {
+			Comment "Stereo Headset 6 Headmic"
+			Value {
+				CapturePriority 200
+				CapturePCM "hw:${CardId},5"
+				CaptureVolume "PGA12.0 12 Master Capture Volume"
+				CaptureChannels "2"
+			}
+		}
+	}
+}
+
+If.pipe14 {
+        Condition {
+                Type ControlExists
+                Control "name='PGA14.0 14 PCM 7 Playback Volume'"
+        }
+        True {
+                SectionDevice."Headset7 Headphone" {
+                        Comment "Stereo Headset 7 Headphone"
+                        Value {
+                                PlaybackPriority 200
+                                PlaybackPCM "hw:${CardId},7"
+                                PlaybackVolume "PGA14.0 14 PCM 7 Playback Volume"
+                                PlaybackChannels "2"
+                        }
+                }
+        }
+}
+
+#
+#SectionDevice."Headphone1" {
+#	Comment "Stereo Headphone1"
+#	EnableSequence [
+#		cset "name='PGA1.1 1 Master Playback Volume' 100"
+#	]
+#	Value {
+#		PlaybackPriority 200
+#		PlaybackPCM "hw:${CardId},0"
+#		PlaybackVolume "PGA1.1 1 Master Playback Volume"
+#		PlaybackChannels "2"
+#	}
+#}
+#

--- a/ucm2/sof-nocodec/sof-nocodec.conf
+++ b/ucm2/sof-nocodec/sof-nocodec.conf
@@ -1,0 +1,6 @@
+Syntax 2
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play HiFi quality Music"
+}


### PR DESCRIPTION
This patch adds the sof-nocodec support.

DMIC is not supported in this ucm2 conf.

Signed-off-by: Libin Yang <libin.yang@linux.intel.com>