### PR TITLE
[DON'T MERGE] add initial ucm support for sof-soundwire on Olympic

### DIFF
--- a/ucm/sof-soundwire/Hdmi1.conf
+++ b/ucm/sof-soundwire/Hdmi1.conf
@@ -1,0 +1,34 @@
+# Use case Configuration for sof-soundwire
+
+SectionVerb {
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+	]
+}
+
+SectionDevice."HDMI1" {
+	Comment "HDMI1/DP1 Output"
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='IEC958 Playback Switch' on"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='IEC958 Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:sofsoundwire,5"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=5 Jack"
+	}
+}
+
+<sof-soundwire/Mics.conf>

--- a/ucm/sof-soundwire/Hdmi2.conf
+++ b/ucm/sof-soundwire/Hdmi2.conf
@@ -1,0 +1,34 @@
+# Use case Configuration for sof-soundwire
+
+SectionVerb {
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+	]
+}
+
+SectionDevice."HDMI2" {
+	Comment "HDMI2/DP2 Output"
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='IEC958 Playback Switch',index=1 on"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='IEC958 Playback Switch',index=1 off"
+	]
+
+	Value {
+		PlaybackPCM "hw:sofsoundwire,6"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=6 Jack"
+	}
+}
+
+<sof-soundwire/Mics.conf>

--- a/ucm/sof-soundwire/Hdmi3.conf
+++ b/ucm/sof-soundwire/Hdmi3.conf
@@ -1,0 +1,34 @@
+# Use case Configuration for sof-soundwire
+
+SectionVerb {
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+	]
+}
+
+SectionDevice."HDMI3" {
+	Comment "HDMI3/DP3 Output"
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='IEC958 Playback Switch',index=2 on"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='IEC958 Playback Switch',index=2 off"
+	]
+
+	Value {
+		PlaybackPCM "hw:sofsoundwire,7"
+		PlaybackChannels "2"
+		JackControl "HDMI/DP,pcm=7 Jack"
+	}
+}
+
+<sof-soundwire/Mics.conf>

--- a/ucm/sof-soundwire/HiFi.conf
+++ b/ucm/sof-soundwire/HiFi.conf
@@ -1,0 +1,32 @@
+# Use case Configuration for sof-soundwire
+
+SectionVerb {
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='PGA1.0 1 Master Playback Volume' 80"
+	]
+
+}
+
+SectionDevice."Headphone" {
+	Comment "Headphone"
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='rt711 DAC Surr Playback Volume' 87"
+		cset "name='Headphone Switch' on"
+	]
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='Headphone Switch' off"
+	]
+	Value {
+		PlaybackPCM "hw:sofsoundwire,0"
+		PlaybackChannels "2"
+		JackControl "Headphone Jack"
+		PlaybackPriority "200"
+	}
+}
+
+<sof-soundwire/Mics.conf>

--- a/ucm/sof-soundwire/Mics.conf
+++ b/ucm/sof-soundwire/Mics.conf
@@ -1,0 +1,55 @@
+SectionVerb {
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='rt711 ADC 23 Mux' 'MIC2'"
+		cset "name='rt711 ADC 08 Capture Volume' 63"
+		cset "name='rt711 ADC 08 Capture Switch' 1"
+		cset "name='rt711 AMIC Volume' 1"
+		cset "name='rt715 DMIC3 Boost' 2"
+		cset "name='rt715 DMIC4 Boost' 2"
+		cset "name='rt715 ADC 24 Mux' 3"
+		cset "name='rt715 ADC 25 Mux' 4"
+		cset "name='rt715 ADC 27 Capture Switch' 1"
+		cset "name='rt715 ADC 07 Capture Switch' 1"
+		cset "name='PGA2.0 2 Master Capture Switch' 1"
+		cset "name='PGA5.0 5 Master Capture Switch' 1"
+	]
+}
+
+SectionDevice."Microphone" {
+	Comment "Headset Mic"
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+	]
+	Value {
+		CaptureSwitch "PGA2.0 2 Master Capture Switch"
+		CaptureVolume "PGA2.0 2 Master Capture Volume"
+		CapturePCM "hw:sofsoundwire,1"
+		CaptureChannels "2"
+		JackControl "Headset Mic Jack"
+	}
+}
+
+SectionDevice."Dmic" {
+	Comment "Digital Microphone"
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+	]
+
+	Value {
+		CaptureSwitch "PGA5.0 5 Master Capture Switch"
+		CaptureVolume "PGA5.0 5 Master Capture Volume"
+		CapturePCM "hw:sofsoundwire,4"
+		CaptureChannels "2"
+	}
+}

--- a/ucm/sof-soundwire/Speaker.conf
+++ b/ucm/sof-soundwire/Speaker.conf
@@ -1,0 +1,33 @@
+# Use case Configuration for sof-soundwire
+
+SectionVerb {
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='PGA3.0 3 Master Playback Volume' 80"
+	]
+
+}
+
+SectionDevice."Speaker" {
+	Comment "Speaker"
+
+	EnableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='rt1308-1 DAC L Switch' 1"
+		cset "name='rt1308-1 DAC R Switch' 1"
+		cset "name='Speaker Switch' on"
+	]
+	DisableSequence [
+		cdev "hw:sofsoundwire"
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:sofsoundwire,2"
+		PlaybackChannels "2"
+		PlaybackPriority "100"
+	}
+}
+
+<sof-soundwire/Mics.conf>

--- a/ucm/sof-soundwire/sof-soundwire.conf
+++ b/ucm/sof-soundwire/sof-soundwire.conf
@@ -1,0 +1,25 @@
+
+SectionUseCase."Speaker" {
+	File "Speaker.conf"
+	Comment "Play to Speaker"
+}
+
+SectionUseCase."HiFi" {
+	File "HiFi.conf"
+	Comment "Play HiFi quality Music"
+}
+
+SectionUseCase."Hdmi1" {
+	File "Hdmi1.conf"
+	Comment "Play to Hdmi1"
+}
+
+SectionUseCase."Hdmi2" {
+	File "Hdmi2.conf"
+	Comment "Play to Hdmi2"
+}
+
+SectionUseCase."Hdmi3" {
+	File "Hdmi3.conf"
+	Comment "Play to Hdmi3"
+}


### PR DESCRIPTION
This patch is only for Olympic project for sof-soundwire on Ubuntu. The PR is used to share the UCM with customers. This patch should not be merged.