### PR TITLE
sof-soundwire: split speaker configuration for 2 and 4ch cases

### DIFF
--- a/ucm2/sof-soundwire/HiFi.conf
+++ b/ucm2/sof-soundwire/HiFi.conf
@@ -11,6 +11,6 @@ SectionVerb {
 <sof-soundwire/RT700.conf>
 <sof-soundwire/RT711.conf>
 <sof-soundwire/RT5682.conf>
-<sof-soundwire/RT1308-1.conf>
+<sof-soundwire/RT1308.conf>
 <sof-soundwire/RT715.conf>
 <sof-soundwire/Hdmi.conf>

--- a/ucm2/sof-soundwire/RT1308-2.conf
+++ b/ucm2/sof-soundwire/RT1308-2.conf
@@ -4,16 +4,23 @@ SectionDevice."Speaker" {
 	Comment	"Speaker"
 
 	EnableSequence [
-		cset "name='PGA3.0 3 Master Playback Volume' 50"
+		cset "name='PGA3.1 3 Master Playback Volume' 50"
+
+		cset "name='rt1308-1 RX Channel Select' LL"
+		cset "name='rt1308-2 RX Channel Select' RR"
 
 		cset "name='rt1308-1 DAC L Switch' 1"
 		cset "name='rt1308-1 DAC R Switch' 1"
+		cset "name='rt1308-2 DAC L Switch' 1"
+		cset "name='rt1308-2 DAC R Switch' 1"
 		cset "name='Speaker Switch' on"
 	]
 
 	DisableSequence [
 		cset "name='rt1308-1 DAC L Switch' 0"
 		cset "name='rt1308-1 DAC R Switch' 0"
+		cset "name='rt1308-2 DAC L Switch' 0"
+		cset "name='rt1308-2 DAC R Switch' 0"
 		cset "name='Speaker Switch' off"
 	]
 

--- a/ucm2/sof-soundwire/RT1308.conf
+++ b/ucm2/sof-soundwire/RT1308.conf
@@ -1,0 +1,30 @@
+# Use case Configuration for sof-soundwire card
+# alsaucm -c sof-soundwire  set _verb HiFi set _enadev Speaker
+
+If.RT1308 {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "spk:rt1308"
+	}
+	True {
+
+		If.2ch {
+			Condition {
+				Type String
+				Haystack "${CardComponents}"
+				Needle "cfg-spk:2"
+			}
+			True {
+
+<sof-soundwire/RT1308-1.conf>
+
+			}
+			False {
+
+<sof-soundwire/RT1308-2.conf>
+
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add tests and separate files for configurations

Fixes: https://github.com/thesofproject/linux/issues/1998

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>