### PR TITLE
sof-soundwire: Hdmi: setup volume in EnableSequence

### DIFF
--- a/ucm2/sof-soundwire/Hdmi.conf
+++ b/ucm2/sof-soundwire/Hdmi.conf
@@ -10,6 +10,7 @@ If.hdmi1 {
 			Comment "HDMI1/DP1 Output"
 
 			EnableSequence [
+				cset "name='PGA6.0 6 Master Playback Volume' 32"
 				cset "name='IEC958 Playback Switch' on"
 			]
 
@@ -36,6 +37,7 @@ If.hdmi2 {
 			Comment "HDMI2/DP2 Output"
 
 			EnableSequence [
+				cset "name='PGA7.0 7 Master Playback Volume' 32"
 				cset "name='IEC958 Playback Switch',index=1 on"
 			]
 
@@ -62,6 +64,7 @@ If.hdmi3 {
 			Comment "HDMI3/DP3 Output"
 
 			EnableSequence [
+				cset "name='PGA8.0 8 Master Playback Volume' 32"
 				cset "name='IEC958 Playback Switch',index=2 on"
 			]
 


### PR DESCRIPTION
Setup the HDMI volume in EnableSequence. With this patch, hdmi is
independent on the unpredictable initial state.

Signed-off-by: Libin Yang <libin.yang@linux.intel.com>