### PR TITLE
[RFC] sof-soundwire: setup the initial values

### DIFF
--- a/ucm2/sof-soundwire/HiFi.conf
+++ b/ucm2/sof-soundwire/HiFi.conf
@@ -2,9 +2,197 @@
 
 SectionVerb {
 
-	EnableSequence [
-		cset "name='PGA1.0 1 Master Playback Volume' 50"
-	]
+If.seq1p {
+	Condition {
+		Type ControlExists
+		Control "name='PGA1.0 1 Master Playback Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA1.0 1 Master Playback Volume' 32"
+		]
+	}
+}
+
+If.seq2p {
+	Condition {
+		Type ControlExists
+		Control "name='PGA2.0 2 Master Playback Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA2.0 2 Master Playback Volume' 32"
+		]
+	}
+}
+
+If.seq3p {
+	Condition {
+		Type ControlExists
+		Control "name='PGA3.0 3 Master Playback Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA3.0 3 Master Playback Volume' 32"
+		]
+	}
+}
+
+If.seq4p {
+	Condition {
+		Type ControlExists
+		Control "name='PGA4.0 4 Master Playback Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA4.0 4 Master Playback Volume' 32"
+		]
+	}
+}
+
+If.seq5p {
+	Condition {
+		Type ControlExists
+		Control "name='PGA5.0 5 Master Playback Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA5.0 5 Master Playback Volume' 32"
+		]
+	}
+}
+
+If.seq6p {
+	Condition {
+		Type ControlExists
+		Control "name='PGA6.0 6 Master Playback Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA6.0 6 Master Playback Volume' 32"
+		]
+	}
+}
+
+If.seq7p {
+	Condition {
+		Type ControlExists
+		Control "name='PGA7.0 7 Master Playback Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA7.0 7 Master Playback Volume' 32"
+		]
+	}
+}
+
+If.seq8p {
+	Condition {
+		Type ControlExists
+		Control "name='PGA8.0 8 Master Playback Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA8.0 8 Master Playback Volume' 32"
+		]
+	}
+}
+
+If.seq1c {
+	Condition {
+		Type ControlExists
+		Control "name='PGA1.0 1 Master Capture Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA1.0 1 Master Capture Volume' 50"
+		]
+	}
+}
+
+If.seq2c {
+	Condition {
+		Type ControlExists
+		Control "name='PGA2.0 2 Master Capture Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA2.0 2 Master Capture Volume' 50"
+		]
+	}
+}
+
+If.seq3c {
+	Condition {
+		Type ControlExists
+		Control "name='PGA3.0 3 Master Capture Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA3.0 3 Master Capture Volume' 50"
+		]
+	}
+}
+
+If.seq4c {
+	Condition {
+		Type ControlExists
+		Control "name='PGA4.0 4 Master Capture Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA4.0 4 Master Capture Volume' 50"
+		]
+	}
+}
+
+If.seq5c {
+	Condition {
+		Type ControlExists
+		Control "name='PGA5.0 5 Master Capture Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA5.0 5 Master Capture Volume' 50"
+		]
+	}
+}
+
+If.seq6c {
+	Condition {
+		Type ControlExists
+		Control "name='PGA6.0 6 Master Capture Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA6.0 6 Master Capture Volume' 50"
+		]
+	}
+}
+
+If.seq7c {
+	Condition {
+		Type ControlExists
+		Control "name='PGA7.0 7 Master Capture Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA7.0 7 Master Capture Volume' 50"
+		]
+	}
+}
+
+If.seq8c {
+	Condition {
+		Type ControlExists
+		Control "name='PGA8.0 8 Master Capture Volume'"
+	}
+	True {
+		EnableSequence [
+			cset "name='PGA8.0 8 Master Capture Volume' 50"
+		]
+	}
+}
 
 }
 

--- a/ucm2/sof-soundwire/RT1308-1.conf
+++ b/ucm2/sof-soundwire/RT1308-1.conf
@@ -12,8 +12,6 @@ If.RT1308-1 {
 			Comment	"Speaker"
 
 			EnableSequence [
-				cset "name='PGA3.0 3 Master Playback Volume' 50"
-
 				cset "name='rt1308-1 DAC L Switch' 1"
 				cset "name='rt1308-1 DAC R Switch' 1"
 				cset "name='Speaker Switch' on"


### PR DESCRIPTION
This patch sets up the initial values of the kcontrols to make sure the
audio is in the predictable state.

Signed-off-by: Libin Yang <libin.yang@linux.intel.com>

---
Please don't merge. Just for discussion.