### PR TITLE
Sdw ucm2 rt700 and priority

### DIFF
--- a/ucm2/sof-soundwire/RT1308-1.conf
+++ b/ucm2/sof-soundwire/RT1308-1.conf
@@ -26,7 +26,7 @@ If.RT1308-1 {
 			]
 
 			Value {
-			      PlaybackPriority 300
+			      PlaybackPriority 100
 			      PlaybackPCM "hw:${CardId},2"
 			      PlaybackChannels "2"
 			}

--- a/ucm2/sof-soundwire/RT700.conf
+++ b/ucm2/sof-soundwire/RT700.conf
@@ -18,10 +18,11 @@ If.RT700 {
 			EnableSequence [
 				cset "name='DAC Front Playback Volume' 87"
 				cset "name='HPO Mux' 'Front'"
+				cset "name='Headphones Switch' on"
 			]
 
 			DisableSequence [
-
+				cset "name='Headphones Switch' off"
 			]
 
 			Value {
@@ -40,11 +41,12 @@ If.RT700 {
 			]
 
 			EnableSequence [
+				cset "name='Speaker Switch' on"
 				cset "name='DAC Front Playback Volume' 87"
 			]
 
 			DisableSequence [
-
+				cset "name='Speaker Switch' off"
 			]
 
 			Value {

--- a/ucm2/sof-soundwire/RT700.conf
+++ b/ucm2/sof-soundwire/RT700.conf
@@ -50,7 +50,7 @@ If.RT700 {
 			]
 
 			Value {
-			      PlaybackPriority 300
+			      PlaybackPriority 100
 			      PlaybackPCM "hw:${CardId},0"
 			      PlaybackChannels "2"
 			}

--- a/ucm2/sof-soundwire/RT715.conf
+++ b/ucm2/sof-soundwire/RT715.conf
@@ -30,7 +30,7 @@ If.RT715 {
 			]
 
 			Value {
-			      CapturePriority 300
+			      CapturePriority 100
 			      CapturePCM "hw:${CardId},4"
 			      CaptureChannels "2"
 			      CaptureSwitch "PGA5.0 5 Master Capture Switch"


### PR DESCRIPTION
This patchset:
1. add speaker and headphone switch control in RT700. RT700 uses the same PCM for speaker and headphone, so we should use kcontrol to control the sound output.
2. refine the speaker and DMIC priority to make headset is used when it is plugged in.