### PR TITLE
sof-soundwire: fix rt5682

### DIFF
--- a/ucm2/sof-soundwire/RT5682.conf
+++ b/ucm2/sof-soundwire/RT5682.conf
@@ -12,7 +12,7 @@ If.RT5682 {
 			Comment	"Headphone"
 
 			EnableSequence [
-				cset "name='Headphone Jack' on"
+				cset "name='Headphone Switch' on"
 				cset "name='rt5682 HPOL Playback Switch' 1"
 				cset "name='rt5682 HPOR Playback Switch' 1"
 				cset "name='rt5682 Stereo1 DAC MIXL DAC L1 Switch' 1"
@@ -24,6 +24,8 @@ If.RT5682 {
 			DisableSequence [
 				cset "name='rt5682 HPOL Playback Switch' 0"
 				cset "name='rt5682 HPOR Playback Switch' 0"
+				cset "name='Headphone Switch' off"
+
 			]
 
 			Value {
@@ -38,10 +40,11 @@ If.RT5682 {
 			Comment "Headset Mic"
 
 			EnableSequence [
-				cset "name='STO1 ADC Capture Switch' 1"
+				cset "name='Headset Mic Switch' on"
+				cset "name='rt5682 STO1 ADC Capture Switch' 1"
 				cset "name='rt5682 RECMIX1L CBJ Switch' 1"
-				cset "name='IF1 01 ADC Swap Mux' 2"
-				cset "name='CBJ Boost Volume' 3"
+				cset "name='rt5682 IF1 01 ADC Swap Mux' 2"
+				cset "name='rt5682 CBJ Boost Volume' 3"
 				cset "name='rt5682 Stereo1 ADC L Mux' 0"
 				cset "name='rt5682 Stereo1 ADC R Mux' 0"
 				cset "name='rt5682 Stereo1 ADC L1 Mux' 1"
@@ -53,10 +56,11 @@ If.RT5682 {
 			]
 
 			DisableSequence [
-				cset "name='STO1 ADC Capture Switch' 0"
+				cset "name='rt5682 STO1 ADC Capture Switch' 0"
 				cset "name='rt5682 RECMIX1L CBJ Switch' 0"
 				cset "name='rt5682 Stereo1 ADC MIXL ADC1 Switch' 0"
 				cset "name='rt5682 Stereo1 ADC MIXR ADC1 Switch' 0"
+				cset "name='Headset Mic Switch' off"
 			]
 
 			Value {


### PR DESCRIPTION
We need to set the Headphone Switch and Headset Mic Switch as
needed. The Jack controls are read-only

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>