### PR TITLE
sof-soundwire: set PGA volume to 32

### DIFF
--- a/ucm2/sof-soundwire/HiFi.conf
+++ b/ucm2/sof-soundwire/HiFi.conf
@@ -3,7 +3,7 @@
 SectionVerb {
 
 	EnableSequence [
-		cset "name='PGA1.0 1 Master Playback Volume' 50"
+		cset "name='PGA1.0 1 Master Playback Volume' 32"
 	]
 
 }

--- a/ucm2/sof-soundwire/RT1308-1.conf
+++ b/ucm2/sof-soundwire/RT1308-1.conf
@@ -4,7 +4,7 @@ SectionDevice."Speaker" {
 	Comment	"Speaker"
 
 	EnableSequence [
-		cset "name='PGA3.0 3 Master Playback Volume' 50"
+		cset "name='PGA3.0 3 Master Playback Volume' 32"
 
 		cset "name='rt1308-1 DAC L Switch' 1"
 		cset "name='rt1308-1 DAC R Switch' 1"

--- a/ucm2/sof-soundwire/RT1308-2.conf
+++ b/ucm2/sof-soundwire/RT1308-2.conf
@@ -4,7 +4,7 @@ SectionDevice."Speaker" {
 	Comment	"Speaker"
 
 	EnableSequence [
-		cset "name='PGA3.1 3 Master Playback Volume' 50"
+		cset "name='PGA3.1 3 Master Playback Volume' 32"
 
 		cset "name='rt1308-1 RX Channel Select' LL"
 		cset "name='rt1308-2 RX Channel Select' RR"


### PR DESCRIPTION
Max value of playback pipeline PGA volume is 32 and 50 is
out of its range.

Set playback pipeline PGA volume to 32, which is 0db.

Signed-off-by: Libin Yang <libin.yang@linux.intel.com>