### PR TITLE
Init kcontrol values for sof-hda-dsp and sof-soundwire

### DIFF
--- a/ucm2/codecs/rt5682/init.conf
+++ b/ucm2/codecs/rt5682/init.conf
@@ -1,0 +1,24 @@
+# RT5682 specific volume control settings
+If.RT5682init {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "hs:rt5682"
+	}
+	True {
+		BootSequence [
+			cset "name='rt5682 Stereo1 DAC MIXL DAC L1 Switch' 1"
+			cset "name='rt5682 Stereo1 DAC MIXR DAC R1 Switch' 1"
+			cset "name='rt5682 DAC L Mux' 1"
+			cset "name='rt5682 DAC R Mux' 1"
+			cset "name='rt5682 IF1 01 ADC Swap Mux' 2"
+			cset "name='rt5682 CBJ Boost Volume' 3"
+			cset "name='rt5682 Stereo1 ADC L Mux' 0"
+			cset "name='rt5682 Stereo1 ADC R Mux' 0"
+			cset "name='rt5682 Stereo1 ADC L1 Mux' 1"
+			cset "name='rt5682 Stereo1 ADC R1 Mux' 1"
+			cset "name='rt5682 Stereo1 ADC MIXL ADC2 Switch' 0"
+			cset "name='rt5682 Stereo1 ADC MIXR ADC2 Switch' 0"
+		]
+	}
+}

--- a/ucm2/codecs/rt700/init.conf
+++ b/ucm2/codecs/rt700/init.conf
@@ -1,0 +1,17 @@
+# RT700 specific volume control settings
+If.rt700init {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "hs:rt700"
+	}
+	True {
+		BootSequence [
+			cset "name='DAC Front Playback Volume' 87"
+			cset "name='HPO Mux' 'Front'"
+			cset "name='ADC 09 Capture Volume' 63"
+			cset "name='ADC 22 Mux' 'MIC2'"
+			cset "name='AMIC Volume' 1"
+		]
+	}
+}

--- a/ucm2/codecs/rt711/init.conf
+++ b/ucm2/codecs/rt711/init.conf
@@ -1,0 +1,17 @@
+# RT711 specific volume control settings
+If.rt711init {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "hs:rt711"
+	}
+	True {
+		BootSequence [
+			cset "name='rt711 DAC Surr Playback Volume' 87"
+			cset "name='rt711 ADC 08 Capture Volume' 63"
+			cset "name='rt711 ADC 23 Mux' 'MIC2'"
+			cset "name='rt711 ADC 08 Capture Switch' 1"
+			cset "name='rt711 AMIC Volume' 1"
+		]
+	}
+}

--- a/ucm2/codecs/rt715/init.conf
+++ b/ucm2/codecs/rt715/init.conf
@@ -1,0 +1,19 @@
+# RT715 specific volume control settings
+If.RT715init {
+	Condition {
+		Type String
+		Haystack "${CardComponents}"
+		Needle "mic:rt715"
+	}
+	True {
+		BootSequence [
+			cset "name='rt715 DMIC3 Boost' 2"
+			cset "name='rt715 DMIC4 Boost' 2"
+			cset "name='rt715 ADC 24 Mux' 3"
+			cset "name='rt715 ADC 25 Mux' 4"
+			cset "name='rt715 ADC 27 Capture Switch' 1"
+			cset "name='rt715 ADC 07 Capture Switch' 1"
+
+		]
+	}
+}

--- a/ucm2/sof-soundwire/HiFi.conf
+++ b/ucm2/sof-soundwire/HiFi.conf
@@ -1,13 +1,5 @@
 # Use case Configuration for sof-soundwire card
 
-SectionVerb {
-
-	EnableSequence [
-		cset "name='PGA1.0 1 Master Playback Volume' 50"
-	]
-
-}
-
 <sof-soundwire/RT700.conf>
 <sof-soundwire/RT711.conf>
 <sof-soundwire/RT5682.conf>

--- a/ucm2/sof-soundwire/RT1308-1.conf
+++ b/ucm2/sof-soundwire/RT1308-1.conf
@@ -4,8 +4,6 @@ SectionDevice."Speaker" {
 	Comment	"Speaker"
 
 	EnableSequence [
-		cset "name='PGA3.0 3 Master Playback Volume' 50"
-
 		cset "name='rt1308-1 DAC L Switch' 1"
 		cset "name='rt1308-1 DAC R Switch' 1"
 		cset "name='Speaker Switch' on"

--- a/ucm2/sof-soundwire/RT1308-2.conf
+++ b/ucm2/sof-soundwire/RT1308-2.conf
@@ -4,8 +4,6 @@ SectionDevice."Speaker" {
 	Comment	"Speaker"
 
 	EnableSequence [
-		cset "name='PGA3.1 3 Master Playback Volume' 50"
-
 		cset "name='rt1308-1 RX Channel Select' LL"
 		cset "name='rt1308-2 RX Channel Select' RR"
 

--- a/ucm2/sof-soundwire/RT5682.conf
+++ b/ucm2/sof-soundwire/RT5682.conf
@@ -15,10 +15,6 @@ If.RT5682 {
 				cset "name='Headphone Switch' on"
 				cset "name='rt5682 HPOL Playback Switch' 1"
 				cset "name='rt5682 HPOR Playback Switch' 1"
-				cset "name='rt5682 Stereo1 DAC MIXL DAC L1 Switch' 1"
-				cset "name='rt5682 Stereo1 DAC MIXR DAC R1 Switch' 1"
-				cset "name='rt5682 DAC L Mux' 1"
-				cset "name='rt5682 DAC R Mux' 1"
 			]
 
 			DisableSequence [
@@ -43,14 +39,6 @@ If.RT5682 {
 				cset "name='Headset Mic Switch' on"
 				cset "name='rt5682 STO1 ADC Capture Switch' 1"
 				cset "name='rt5682 RECMIX1L CBJ Switch' 1"
-				cset "name='rt5682 IF1 01 ADC Swap Mux' 2"
-				cset "name='rt5682 CBJ Boost Volume' 3"
-				cset "name='rt5682 Stereo1 ADC L Mux' 0"
-				cset "name='rt5682 Stereo1 ADC R Mux' 0"
-				cset "name='rt5682 Stereo1 ADC L1 Mux' 1"
-				cset "name='rt5682 Stereo1 ADC R1 Mux' 1"
-				cset "name='rt5682 Stereo1 ADC MIXL ADC2 Switch' 0"
-				cset "name='rt5682 Stereo1 ADC MIXR ADC2 Switch' 0"
 				cset "name='rt5682 Stereo1 ADC MIXL ADC1 Switch' 1"
 				cset "name='rt5682 Stereo1 ADC MIXR ADC1 Switch' 1"
 			]

--- a/ucm2/sof-soundwire/RT700.conf
+++ b/ucm2/sof-soundwire/RT700.conf
@@ -16,8 +16,6 @@ If.RT700 {
 			]
 
 			EnableSequence [
-				cset "name='DAC Front Playback Volume' 87"
-				cset "name='HPO Mux' 'Front'"
 				cset "name='Headphones Switch' on"
 			]
 
@@ -42,7 +40,6 @@ If.RT700 {
 
 			EnableSequence [
 				cset "name='Speaker Switch' on"
-				cset "name='DAC Front Playback Volume' 87"
 			]
 
 			DisableSequence [
@@ -60,10 +57,7 @@ If.RT700 {
 			Comment "Headset Mic"
 
 			EnableSequence [
-				cset "name='ADC 22 Mux' 'MIC2'"
-				cset "name='ADC 09 Capture Volume' 63"
 				cset "name='ADC 09 Capture Switch' 1"
-				cset "name='AMIC Volume' 1"
 			]
 
 			DisableSequence [

--- a/ucm2/sof-soundwire/RT711.conf
+++ b/ucm2/sof-soundwire/RT711.conf
@@ -12,7 +12,6 @@ If.RT711 {
 			Comment	"Headphone"
 
 			EnableSequence [
-				cset "name='rt711 DAC Surr Playback Volume' 87"
 				cset "name='Headphone Switch' on"
 			]
 
@@ -32,11 +31,6 @@ If.RT711 {
 			Comment "Headset Mic"
 
 			EnableSequence [
-				cset "name='rt711 ADC 23 Mux' 'MIC2'"
-				cset "name='rt711 ADC 08 Capture Volume' 63"
-				cset "name='rt711 ADC 08 Capture Switch' 1"
-				cset "name='rt711 AMIC Volume' 1"
-
 				cset "name='PGA2.0 2 Master Capture Switch' 1"
 			]
 

--- a/ucm2/sof-soundwire/RT715.conf
+++ b/ucm2/sof-soundwire/RT715.conf
@@ -12,20 +12,10 @@ If.RT715 {
 			Comment	"SoundWire microphones"
 
 			EnableSequence [
-				cset "name='rt715 DMIC3 Boost' 2"
-				cset "name='rt715 DMIC4 Boost' 2"
-				cset "name='rt715 ADC 24 Mux' 3"
-				cset "name='rt715 ADC 25 Mux' 4"
-				cset "name='rt715 ADC 27 Capture Switch' 1"
-				cset "name='rt715 ADC 07 Capture Switch' 1"
-
 				cset "name='PGA5.0 5 Master Capture Switch' 1"
 			]
 
 			DisableSequence [
-				cset "name='rt715 ADC 27 Capture Switch' 0"
-				cset "name='rt715 ADC 07 Capture Switch' 0"
-
 				cset "name='PGA5.0 5 Master Capture Switch' 0"
 			]
 

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -4,3 +4,8 @@ SectionUseCase."HiFi" {
 	File "HiFi.conf"
 	Comment "Play HiFi quality Music"
 }
+
+<codecs/rt5682/init.conf>
+<codecs/rt700/init.conf>
+<codecs/rt711/init.conf>
+<codecs/rt715/init.conf>


### PR DESCRIPTION
This patch adds the initial kcontrol values for sof-hda-dsp and move the initial kcontrol values into SectionOnce.
Move the initial kcontrols values into SectionOnce can avoid setting the kcontrol values everytime the device is used.
Please see the detail discussion in https://github.com/thesofproject/linux/issues/2067