### PR TITLE
sof-soundwire: initial support for SoundWire/SDCA devices

### DIFF
--- a/ucm2/codecs/rt711-sdca/init.conf
+++ b/ucm2/codecs/rt711-sdca/init.conf
@@ -1,0 +1,8 @@
+# RT711-sdca specific volume control settings
+
+BootSequence [
+	cset "name='rt711 FU05 Playback Volume' 87"
+	cset "name='rt711 ADC 22 Mux' 'MIC2'"
+	cset "name='rt711 FU0F Capture Volume' 23"
+	cset "name='rt711 FU0F Capture Switch' 1"
+]

--- a/ucm2/codecs/rt715-sdca/init.conf
+++ b/ucm2/codecs/rt715-sdca/init.conf
@@ -1,0 +1,11 @@
++# RT715-sdca (aka RT714) specific volume control settings
+
+BootSequence [
+	cset "name='rt714 FU02 3_4 Capture Switch' 1"
+	cset "name='rt714 FU02 1_2 Capture Switch' 1"
+	cset "name='rt714 FU0A Capture Switch' 0"
+	cset "name='rt714 ADC 22 Mux' 'DMIC3'"
+	cset "name='rt714 ADC 23 Mux' 'DMIC4'"
+	cset "name='rt714 FU02 3_4 Capture Volume' 48 48"
+	cset "name='rt714 FU02 1_2 Capture Volume' 48 48"
+]

--- a/ucm2/sof-soundwire/HiFi.conf
+++ b/ucm2/sof-soundwire/HiFi.conf
@@ -9,7 +9,7 @@ If.spkdev {
 		Type String
 		Empty "${var:SpeakerCodec1}"
 	}
-	False.Include.spkdev.File "/sof-soundwire/${var:SpeakerCodec1}-${var:SpeakerChannels1}.conf"
+	False.Include.spkdev.File "/sof-soundwire/${var:SpeakerCodec1}-${var:SpeakerAmps1}.conf"
 }
 
 If.micdev {

--- a/ucm2/sof-soundwire/rt1308-1.conf
+++ b/ucm2/sof-soundwire/rt1308-1.conf
@@ -4,21 +4,14 @@ SectionDevice."Speaker" {
 	Comment	"Speaker"
 
 	EnableSequence [
-		cset "name='rt1308-1 RX Channel Select' LL"
-		cset "name='rt1308-2 RX Channel Select' RR"
-
 		cset "name='rt1308-1 DAC L Switch' 1"
 		cset "name='rt1308-1 DAC R Switch' 1"
-		cset "name='rt1308-2 DAC L Switch' 1"
-		cset "name='rt1308-2 DAC R Switch' 1"
 		cset "name='Speaker Switch' on"
 	]
 
 	DisableSequence [
 		cset "name='rt1308-1 DAC L Switch' 0"
 		cset "name='rt1308-1 DAC R Switch' 0"
-		cset "name='rt1308-2 DAC L Switch' 0"
-		cset "name='rt1308-2 DAC R Switch' 0"
 		cset "name='Speaker Switch' off"
 	]
 

--- a/ucm2/sof-soundwire/rt1308-2.conf
+++ b/ucm2/sof-soundwire/rt1308-2.conf
@@ -4,14 +4,21 @@ SectionDevice."Speaker" {
 	Comment	"Speaker"
 
 	EnableSequence [
+		cset "name='rt1308-1 RX Channel Select' LL"
+		cset "name='rt1308-2 RX Channel Select' RR"
+
 		cset "name='rt1308-1 DAC L Switch' 1"
 		cset "name='rt1308-1 DAC R Switch' 1"
+		cset "name='rt1308-2 DAC L Switch' 1"
+		cset "name='rt1308-2 DAC R Switch' 1"
 		cset "name='Speaker Switch' on"
 	]
 
 	DisableSequence [
 		cset "name='rt1308-1 DAC L Switch' 0"
 		cset "name='rt1308-1 DAC R Switch' 0"
+		cset "name='rt1308-2 DAC L Switch' 0"
+		cset "name='rt1308-2 DAC R Switch' 0"
 		cset "name='Speaker Switch' off"
 	]
 

--- a/ucm2/sof-soundwire/rt1316-1.conf
+++ b/ucm2/sof-soundwire/rt1316-1.conf
@@ -1,0 +1,22 @@
+# Use case Configuration for sof-soundwire card
+
+SectionDevice."Speaker" {
+	Comment	"Speaker"
+
+	EnableSequence [
+		cset "name='rt1316-1 DAC L Switch' 1"
+		cset "name='rt1316-1 DAC R Switch' 1"
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='rt1316-1 DAC L Switch' 0"
+		cset "name='rt1316-1 DAC R Switch' 0"
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+	      PlaybackPriority 100
+	      PlaybackPCM "hw:${CardId},2"
+	}
+}

--- a/ucm2/sof-soundwire/rt1316-2.conf
+++ b/ucm2/sof-soundwire/rt1316-2.conf
@@ -1,0 +1,29 @@
+# Use case Configuration for sof-soundwire card
+
+SectionDevice."Speaker" {
+	Comment	"Speaker"
+
+	EnableSequence [
+		cset "name='rt1316-1 RX Channel Select' L,L"
+		cset "name='rt1316-2 RX Channel Select' R,R"
+
+		cset "name='rt1316-1 DAC L Switch' 1"
+		cset "name='rt1316-1 DAC R Switch' 1"
+		cset "name='rt1316-2 DAC L Switch' 1"
+		cset "name='rt1316-2 DAC R Switch' 1"
+		cset "name='Speaker Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='rt1316-1 DAC L Switch' 0"
+		cset "name='rt1316-1 DAC R Switch' 0"
+		cset "name='rt1316-2 DAC L Switch' 0"
+		cset "name='rt1316-2 DAC R Switch' 0"
+		cset "name='Speaker Switch' off"
+	]
+
+	Value {
+	      PlaybackPriority 100
+	      PlaybackPCM "hw:${CardId},2"
+	}
+}

--- a/ucm2/sof-soundwire/rt711-sdca.conf
+++ b/ucm2/sof-soundwire/rt711-sdca.conf
@@ -1,0 +1,39 @@
+# Use case Configuration for sof-soundwire card
+
+SectionDevice."Headphones" {
+	Comment	"Headphones"
+
+	EnableSequence [
+		cset "name='Headphone Switch' on"
+	]
+
+	DisableSequence [
+		cset "name='Headphone Switch' off"
+	]
+
+	Value {
+	      PlaybackPriority 200
+	      PlaybackPCM "hw:${CardId}"
+	      JackControl "Headphone Jack"
+	}
+}
+
+SectionDevice."Headset" {
+	Comment "Headset Microphone"
+
+	EnableSequence [
+		cset "name='PGA2.0 2 Master Capture Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='PGA2.0 2 Master Capture Switch' 0"
+	]
+
+	Value {
+		CapturePriority 200
+		CapturePCM "hw:${CardId},1"
+		JackControl "Headset Mic Jack"
+		CaptureSwitch "PGA2.0 2 Master Capture Switch"
+		CaptureVolume "PGA2.0 2 Master Capture Volume"
+	}
+}

--- a/ucm2/sof-soundwire/rt715-sdca.conf
+++ b/ucm2/sof-soundwire/rt715-sdca.conf
@@ -1,0 +1,20 @@
+# Use case Configuration for sof-soundwire card
+
+SectionDevice."Mic" {
+	Comment	"SoundWire microphones"
+
+	EnableSequence [
+		cset "name='PGA5.0 5 Master Capture Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='PGA5.0 5 Master Capture Switch' 0"
+	]
+
+	Value {
+	      CapturePriority 100
+	      CapturePCM "hw:${CardId},4"
+	      CaptureSwitch "PGA5.0 5 Master Capture Switch"
+	      CaptureVolume "PGA5.0 5 Master Capture Volume"
+	}
+}

--- a/ucm2/sof-soundwire/sof-soundwire.conf
+++ b/ucm2/sof-soundwire/sof-soundwire.conf
@@ -15,7 +15,7 @@ Define {
 
 DefineRegex {
 	SpeakerCodec {
-		Regex " spk:([a-z0-9]+)"
+		Regex " spk:([a-z0-9]+(-sdca)?)"
 		String "${CardComponents}"
 	}
 	SpeakerChannels {
@@ -27,11 +27,11 @@ DefineRegex {
 		String "${CardComponents}"
 	}
 	HeadsetCodec {
-		Regex " hs:([a-z0-9]+)"
+		Regex " hs:([a-z0-9]+(-sdca)?)"
 		String "${CardComponents}"
 	}
 	MicCodec {
-		Regex " mic:([a-z0-9]+)"
+		Regex " mic:([a-z0-9]+(-sdca)?)"
 		String "${CardComponents}"
 	}
 }
@@ -39,7 +39,7 @@ DefineRegex {
 If.hs_init {
 	Condition {
 		Type RegexMatch
-		Regex "(rt5682|rt700|rt711)"
+		Regex "(rt5682|rt700|rt711(-sdca)?)"
 		String "${var:HeadsetCodec1}"
 	}
 	True.Include.hs_init.File "/codecs/${var:HeadsetCodec1}/init.conf"
@@ -48,7 +48,7 @@ If.hs_init {
 If.mic_init {
 	Condition {
 		Type RegexMatch
-		Regex "(rt715)"
+		Regex "(rt715(-sdca)?)"
 		String "${var:MicCodec1}"
 	}
 	True.Include.mic_init.File "/codecs/${var:MicCodec1}/init.conf"


### PR DESCRIPTION
First pass to gather feedback on the directions. With the latest integration code, the component string looks like:

````
Components: 'HDA:80862812,80860101,00100000 cfg-spk:2 cfg-amp:2 hs:rt711-sdca spk:rt1316 mic:rt715-sdca'
````
The settings for the amplifiers still need some work, hence the draft status.