### PR TITLE
sof-hda-dsp: set dmic default on

### DIFF
--- a/ucm2/sof-hda-dsp/sof-hda-dsp.conf
+++ b/ucm2/sof-hda-dsp/sof-hda-dsp.conf
@@ -54,5 +54,6 @@ If.Dmic0 {
 	}
 	True.BootSequence [
 		cset "name='Dmic0 Capture Volume' 70%"
+		cset "name='Dmic0 Capture Switch' on"
 	]
 }


### PR DESCRIPTION
The internal mic become default off for dmic machine. Set the switch default on to align with other audio architecture.